### PR TITLE
remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,8 +10,5 @@
         "testing",
         "rest",
         "url"
-    ],
-    "env": {
-        "BUILDPACK_URL": "https://github.com/kr/heroku-buildpack-go.git"
-    }
+    ]
 }


### PR DESCRIPTION
This isn't needed since we launched Go support.
