### PR TITLE
remove BUILDPACK_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ httpstatus := int
 
 ## Deployment
 
-    $ heroku create --buildpack https://github.com/kr/heroku-buildpack-go.git
+    $ heroku create
     $ git push heroku master
     
 ... or just:


### PR DESCRIPTION
This isn't necessary since we launched Go support.
