### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
## Context
*Because this is a Go repo without the need to configure Packagecloud, we don't need a file at all, but it should accomplish the same thing we're doing elsewhere:*

> Allows Dependabot to run Security Updates that include gems from Packagecloud and `insecure-external-code-execution: allow`, but disable Version Updates (non-Security) updates by setting `open-pull-requests-limit: 0`. See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file.

## Risk
None

## References
https://gus.lightning.force.com/a07EE00001ifHfeYAE