### PR TITLE
go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/heroku/urinception
 
-go 1.19
+go 1.22


### PR DESCRIPTION
## Context
<!--
Share some context about why we're making this change.
-->
Bump go to 1.22

## Risk
<!--
Is this change high risk or low risk? Please explain how.
-->
Low

## References
<!--
Provide a link to documentation discussing the need for this PR (e.g. GUS, Quip, Google Doc, Slack convo)
-->
https://go.dev/dl/ shows 1.22 as latest
